### PR TITLE
Missing fastexport

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,12 @@ should apply cleanly to packaged versions as well.
 3. Put git-lp (https://raw.github.com/zyga/git-lp/master/git-lp) somewhere in
    your PATH.
 4. Install bzr-fastimport (sudo apt-get install bzr-fastimport)
+   If you're using Ubuntu 15.10 or newer, chances are that bzr-fastimport is
+   not available in the archive. You can install it as a local plugin by
+   running:
+
+        $ mkdir -p ~/.bazaar/plugins
+        $ bzr branch lp:bzr-fastimport ~/.bazaar/plugins/fastimport
+
+   Make sure that python-fastimport is installed (sudo apt-get install
+   python-fastimport)

--- a/git-lp
+++ b/git-lp
@@ -384,6 +384,7 @@ if [ "$old_revno" != "$new_revno" ] || [ "$force" = 1 ]; then
         --marks .git/launchpad/bzr.+upstream.marks \
         --git-branch launchpad/+upstream \
         .git/launchpad/repo/+upstream 2>/dev/null \
+        || gitlp_error "bzr fast-export failed" \
         | git fast-import \
         --quiet \
         --import-marks-if-exists=.git/launchpad/git.+upstream.marks \


### PR DESCRIPTION
When launched on a vanilla system git-lp init --fetch $some_project failed with a weird:
```
Exporting project history from Bazaar into Git...
fatal: Not a valid object name: 'launchpad/+upstream'.
```
c1a4329 makes this crash in a more informative way

030146c teaches user how to install bzr-fastexport on modern Ubuntus (which was the other pain I always had when setting up git-lp on a new machine)