### PR TITLE
group bzr fast-export with gitlp_error invocations

### DIFF
--- a/git-lp
+++ b/git-lp
@@ -378,13 +378,13 @@ fi
 if [ "$old_revno" != "$new_revno" ] || [ "$force" = 1 ]; then
     # Mirror everything into git 
     echo "Exporting project history from Bazaar into Git..."
-    bzr fast-export \
+    (bzr fast-export \
         --quiet \
         --plain \
         --marks .git/launchpad/bzr.+upstream.marks \
         --git-branch launchpad/+upstream \
         .git/launchpad/repo/+upstream 2>/dev/null \
-        || gitlp_error "bzr fast-export failed" \
+        || gitlp_error "bzr fast-export failed") \
         | git fast-import \
         --quiet \
         --import-marks-if-exists=.git/launchpad/git.+upstream.marks \


### PR DESCRIPTION
Previous sequence was foo || bar | baz which made foo spill stuff to standard
output. In case of git-lp it made bzr fast-export print whole history to
stdout. This manifested only on Xenial.

This patch groups the OR arguments, so piping always works.

Signed-off-by: Maciej Kisielewski maciej.kisielewski@canonical.com
